### PR TITLE
Can specify the command line arguments when running a Windows Service

### DIFF
--- a/content/PowershellModules/configuration.xsd
+++ b/content/PowershellModules/configuration.xsd
@@ -982,6 +982,7 @@
       <xs:extension base="service">
         <xs:attribute name="path" type="xs:string" />
         <xs:attribute name="srvany" type="xs:boolean" default="false" />
+        <xs:attribute name="arguments" type="xs:string" default="" />
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>


### PR DESCRIPTION
Arguments to be used when starting a Windows Service, can now be specified.