### PR TITLE
Handle parallel deployments creating duplicate sensors

### DIFF
--- a/Powershell.Deployment.nuspec
+++ b/Powershell.Deployment.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Powershell.Deployment</id>
-        <version>1.2.2.1</version>
+        <version>1.2.3.0</version>
         <title>Powershell Deployment modules for Visual Studio</title>
         <authors>Stanislaw Wozniak &amp; Taliesin Sisson</authors>
         <owners>Stanislaw Wozniak &amp; Taliesin Sisson</owners>

--- a/content/PowershellModules/PrtgMonitoringInstallation.psm1
+++ b/content/PowershellModules/PrtgMonitoringInstallation.psm1
@@ -385,16 +385,22 @@ function Install-PrtgSensor {
             Write-Log "PrtgSensor sensor property $groupName/$deviceName/$sensorName/timeout set to $sensorTimeout"
         }
 
-        Write-Log "Check for duplicate sensor id for PrtgSensor for $groupName/$deviceName/$sensorName"
-        $sensorIds = Get-PrtgSensors -apiUrl $apiUrl -login $login -passwordHash $passwordHash -groupName $groupName -deviceName $deviceName -sensorName $sensorName
+        $sensorIds=@()
+        do
+        {
+            Write-Log "Check for duplicate sensor id for PrtgSensor for $groupName/$deviceName/$sensorName"
+            $sensorIds = Get-PrtgSensors -apiUrl $apiUrl -login $login -passwordHash $passwordHash -groupName $groupName -deviceName $deviceName -sensorName $sensorName
 
-        if ($sensorIds.Count -gt 1){
-            $sensorIds | Sort-Object | select -skip 1 | %{
-                $sensorId = $_
-                Write-Log "Delete PrtgSensor for $sensorId"
-                Delete-PrtgObject -apiUrl $apiUrl -login $login -passwordHash $passwordHash -objectId $sensorId
+            if ($sensorIds.Count -gt 1){
+                $sensorIds | Sort-Object | select -skip 1 | %{
+                    $sensorId = $_
+                    Write-Log "Delete PrtgSensor for $sensorId"
+                    Delete-PrtgObject -apiUrl $apiUrl -login $login -passwordHash $passwordHash -objectId $sensorId
+                }
+                Write-Log "Wait 5 seconds and then check again"
+                start-sleep -seconds 5
             }
-        }        
+        } while ($sensorIds.Count -gt 1)    
     } else {
         $sensorIds | %{
             $sensorId = $_
@@ -670,16 +676,22 @@ function Install-PrtgConventionServiceBusSubscribeSensors {
             Write-Log "PrtgSensor sensor property $groupName/$deviceName/$sensorName/timeout set to $sensorTimeout"
         }
 
-        Write-Log "Check for duplicate sensor id for PrtgSensor for $groupName/$deviceName/$sensorName"
-        $sensorIds = Get-PrtgSensors -apiUrl $apiUrl -login $login -passwordHash $passwordHash -groupName $groupName -deviceName $deviceName -sensorName $sensorName
+        $sensorIds=@()
+        do
+        {
+            Write-Log "Check for duplicate sensor id for PrtgSensor for $groupName/$deviceName/$sensorName"
+            $sensorIds = Get-PrtgSensors -apiUrl $apiUrl -login $login -passwordHash $passwordHash -groupName $groupName -deviceName $deviceName -sensorName $sensorName
 
-        if ($sensorIds.Count -gt 1){
-            $sensorIds | Sort-Object | select -skip 1 | %{
-                $sensorId = $_
-                Write-Log "Delete duplicate PrtgServiceBusSubscribeSensors for $sensorId"
-                Delete-PrtgObject -apiUrl $apiUrl -login $login -passwordHash $passwordHash -objectId $sensorId
+            if ($sensorIds.Count -gt 1){
+                $sensorIds | Sort-Object | select -skip 1 | %{
+                    $sensorId = $_
+                    Write-Log "Delete PrtgServiceBusSubscribeSensors for $sensorId"
+                    Delete-PrtgObject -apiUrl $apiUrl -login $login -passwordHash $passwordHash -objectId $sensorId
+                }
+                Write-Log "Wait 5 seconds and then check again"
+                start-sleep -seconds 5
             }
-        }
+        } while ($sensorIds.Count -gt 1)          
     } else {
         $sensorIds | %{
             $sensorId = $_    
@@ -958,16 +970,22 @@ function Install-PrtgServiceBusSubscribeSensors {
             Write-Log "PrtgSensor sensor property $groupName/$deviceName/$sensorName/timeout set to $sensorTimeout"
         }
 
-        Write-Log "Check for duplicate sensor id for PrtgSensor for $groupName/$deviceName/$sensorName"
-        $sensorIds = Get-PrtgSensors -apiUrl $apiUrl -login $login -passwordHash $passwordHash -groupName $groupName -deviceName $deviceName -sensorName $sensorName
+        $sensorIds=@()
+        do
+        {
+            Write-Log "Check for duplicate sensor id for PrtgSensor for $groupName/$deviceName/$sensorName"
+            $sensorIds = Get-PrtgSensors -apiUrl $apiUrl -login $login -passwordHash $passwordHash -groupName $groupName -deviceName $deviceName -sensorName $sensorName
 
-        if ($sensorIds.Count -gt 1){
-            $sensorIds | Sort-Object | select -skip 1 | %{
-                $sensorId = $_
-                Write-Log "Delete duplicate PrtgServiceBusSubscribeSensors for $sensorId"
-                Delete-PrtgObject -apiUrl $apiUrl -login $login -passwordHash $passwordHash -objectId $sensorId
+            if ($sensorIds.Count -gt 1){
+                $sensorIds | Sort-Object | select -skip 1 | %{
+                    $sensorId = $_
+                    Write-Log "Delete PrtgServiceBusSubscribeSensors for $sensorId"
+                    Delete-PrtgObject -apiUrl $apiUrl -login $login -passwordHash $passwordHash -objectId $sensorId
+                }
+                Write-Log "Wait 5 seconds and then check again"
+                start-sleep -seconds 5
             }
-        }        
+        } while ($sensorIds.Count -gt 1)           
     } else {
         $sensorIds | %{      
             $sensorId = $_    
@@ -1582,6 +1600,9 @@ function Invoke-WebRequestWithoutException {
         [string] $Uri,
         $maximumRedirection = 5
     )
+
+    $Uri += "&_=$((Get-Date).Ticks)"
+
     $request = $null
     try {
         $response = Invoke-WebRequest -UseBasicParsing -Uri $Uri -MaximumRedirection $maximumRedirection -ErrorAction SilentlyContinue

--- a/content/PowershellModules/PrtgMonitoringInstallation.psm1
+++ b/content/PowershellModules/PrtgMonitoringInstallation.psm1
@@ -372,7 +372,10 @@ function Install-PrtgSensor {
         Write-Log "Setting PrtgSensor sensor property $groupName/$deviceName/$sensorName/exeparams to $sensorParameter"
         $result = Set-PrtgObjectProperty -apiUrl $apiUrl -login $login -passwordHash $passwordHash -objectId $sensorId -propertyName "exeparams" -propertyValue $sensorParameter
         if (!$result){
-            throw "Unable to set prtg sensor property $groupName/$deviceName/$sensorName/exeparams set to $sensorParameter"
+            $sensorIds = Get-PrtgSensors -apiUrl $apiUrl -login $login -passwordHash $passwordHash -groupName $groupName -deviceName $deviceName -sensorName $sensorName | ?{$_ -eq $sensorId}
+            if ($sensorIds){
+                throw "Unable to set prtg sensor property $groupName/$deviceName/$sensorName/exeparams set to $sensorParameter"
+            }
         } 
         Write-Log "PrtgSensor sensor property $groupName/$deviceName/$sensorName/exeparams set to $sensorParameter"
 
@@ -380,7 +383,10 @@ function Install-PrtgSensor {
             Write-Log "Setting PrtgSensor sensor property $groupName/$deviceName/$sensorName/timeout to $sensorParameter"
             $result = Set-PrtgObjectProperty -apiUrl $apiUrl -login $login -passwordHash $passwordHash -objectId $sensorId -propertyName "timeout" -propertyValue $sensorTimeout
             if (!$result){
-                throw "Unable to set prtg sensor property $groupName/$deviceName/$sensorName/timeout set to $sensorTimeout"
+                $sensorIds = Get-PrtgSensors -apiUrl $apiUrl -login $login -passwordHash $passwordHash -groupName $groupName -deviceName $deviceName -sensorName $sensorName | ?{$_ -eq $sensorId}
+                if ($sensorIds){
+                    throw "Unable to set prtg sensor property $groupName/$deviceName/$sensorName/timeout set to $sensorTimeout"
+                }
             } 
             Write-Log "PrtgSensor sensor property $groupName/$deviceName/$sensorName/timeout set to $sensorTimeout"
         }
@@ -663,7 +669,10 @@ function Install-PrtgConventionServiceBusSubscribeSensors {
         Write-Log "Setting PrtgSensor sensor property $groupName/$deviceName/$sensorName/exeparams to $sensorParameter"
         $result = Set-PrtgObjectProperty -apiUrl $apiUrl -login $login -passwordHash $passwordHash -objectId $sensorId -propertyName "exeparams" -propertyValue $sensorParameter
         if (!$result){
-            throw "Unable to set prtg sensor property $groupName/$deviceName/$sensorName/exeparams set to $sensorParameter"
+            $sensorIds = Get-PrtgSensors -apiUrl $apiUrl -login $login -passwordHash $passwordHash -groupName $groupName -deviceName $deviceName -sensorName $sensorName | ?{$_ -eq $sensorId}
+            if ($sensorIds){
+                throw "Unable to set prtg sensor property $groupName/$deviceName/$sensorName/exeparams set to $sensorParameter"
+            }
         } 
         Write-Log "PrtgSensor sensor property $groupName/$deviceName/$sensorName/exeparams set to $sensorParameter"
 
@@ -671,7 +680,10 @@ function Install-PrtgConventionServiceBusSubscribeSensors {
             Write-Log "Setting PrtgSensor sensor property $groupName/$deviceName/$sensorName/timeout to $sensorParameter"
             $result = Set-PrtgObjectProperty -apiUrl $apiUrl -login $login -passwordHash $passwordHash -objectId $sensorId -propertyName "timeout" -propertyValue $sensorTimeout
             if (!$result){
-                throw "Unable to set prtg sensor property $groupName/$deviceName/$sensorName/timeout set to $sensorTimeout"
+                $sensorIds = Get-PrtgSensors -apiUrl $apiUrl -login $login -passwordHash $passwordHash -groupName $groupName -deviceName $deviceName -sensorName $sensorName | ?{$_ -eq $sensorId}
+                if ($sensorIds){
+                    throw "Unable to set prtg sensor property $groupName/$deviceName/$sensorName/timeout set to $sensorTimeout"
+                }
             } 
             Write-Log "PrtgSensor sensor property $groupName/$deviceName/$sensorName/timeout set to $sensorTimeout"
         }
@@ -957,7 +969,10 @@ function Install-PrtgServiceBusSubscribeSensors {
         Write-Log "Setting PrtgSensor sensor property $groupName/$deviceName/$sensorName/exeparams to $sensorParameter"
         $result = Set-PrtgObjectProperty -apiUrl $apiUrl -login $login -passwordHash $passwordHash -objectId $sensorId -propertyName "exeparams" -propertyValue $sensorParameter
         if (!$result){
-            throw "Unable to set prtg sensor property $groupName/$deviceName/$sensorName/exeparams set to $sensorParameter"
+            $sensorIds = Get-PrtgSensors -apiUrl $apiUrl -login $login -passwordHash $passwordHash -groupName $groupName -deviceName $deviceName -sensorName $sensorName | ?{$_ -eq $sensorId}
+            if ($sensorIds){
+                throw "Unable to set prtg sensor property $groupName/$deviceName/$sensorName/exeparams set to $sensorParameter"
+            }
         } 
         Write-Log "PrtgSensor sensor property $groupName/$deviceName/$sensorName/exeparams set to $sensorParameter"
 
@@ -965,7 +980,10 @@ function Install-PrtgServiceBusSubscribeSensors {
             Write-Log "Setting PrtgSensor sensor property $groupName/$deviceName/$sensorName/timeout to $sensorParameter"
             $result = Set-PrtgObjectProperty -apiUrl $apiUrl -login $login -passwordHash $passwordHash -objectId $sensorId -propertyName "timeout" -propertyValue $sensorTimeout
             if (!$result){
-                throw "Unable to set prtg sensor property $groupName/$deviceName/$sensorName/timeout set to $sensorTimeout"
+                $sensorIds = Get-PrtgSensors -apiUrl $apiUrl -login $login -passwordHash $passwordHash -groupName $groupName -deviceName $deviceName -sensorName $sensorName | ?{$_ -eq $sensorId}
+                if ($sensorIds){
+                    throw "Unable to set prtg sensor property $groupName/$deviceName/$sensorName/timeout set to $sensorTimeout"
+                }
             } 
             Write-Log "PrtgSensor sensor property $groupName/$deviceName/$sensorName/timeout set to $sensorTimeout"
         }
@@ -1384,6 +1402,29 @@ function Get-PrtgObjectProperty {
     return $propertyValue
 }
 
+function Test-PrtgObjectProperty {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $apiUrl,     
+        [Parameter(Mandatory = $true)]
+        [string]
+        $login,     
+        [Parameter(Mandatory = $true)]
+        [string]
+        $passwordHash,
+        [Parameter(Mandatory = $true)]
+        [string]
+        $objectId,
+        [Parameter(Mandatory = $true)]
+        [string]
+        $propertyName
+    )
+
+    $property = Get-PrtgObjectProperty -apiUrl $apiUrl -login $login -passwordHash $passwordHash -objectId $objectId -propertyName $propertyName
+    return ($property -ne $null)
+}
+
 function Copy-PrtgSensor {
     param(
         [Parameter(Mandatory = $true)]
@@ -1528,7 +1569,7 @@ function Delete-PrtgObject {
         $apiUrl += "/"
     }          
             
-    $url = "$($apiUrl)api/deleteobject.htm?id=$($objectId)&username=$($login)&passhash=$($passwordHash)"
+    $url = "$($apiUrl)api/deleteobject.htm?id=$($objectId)&approve=1&username=$($login)&passhash=$($passwordHash)"
 
     $response = Invoke-WebRequestWithoutException -Uri $url
     $result = [int]$response.StatusCode -gt 199 -and [int]$response.StatusCode -lt 300


### PR DESCRIPTION
Stop duplicate sensors from being created when deployments are created in parallel