### PR TITLE
NSSM stdout, stderr and working directory configured to sensible default

### DIFF
--- a/Powershell.Deployment.nuspec
+++ b/Powershell.Deployment.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Powershell.Deployment</id>
-        <version>1.2.3.0</version>
+        <version>1.2.4.0</version>
         <title>Powershell Deployment modules for Visual Studio</title>
         <authors>Stanislaw Wozniak &amp; Taliesin Sisson</authors>
         <owners>Stanislaw Wozniak &amp; Taliesin Sisson</owners>

--- a/content/PowershellModules/ServiceInstallation.psm1
+++ b/content/PowershellModules/ServiceInstallation.psm1
@@ -247,6 +247,10 @@ function Install-WindowsService {
 	if ($serviceContainer -eq 'srvany' -or $serviceContainer -eq 'nssm') {	
 		New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\services\$($serviceConfig.name)" -Name "Parameters" –Force
 		New-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\services\$($serviceConfig.name)\Parameters" -Name "Application" -Value "$binPath" -Force
+		New-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\services\$($serviceConfig.name)\Parameters" -Name "AppDirectory" -Value "$rootPath" -Force
+		New-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\services\$($serviceConfig.name)\Parameters" -Name "AppStdout" -Value "$rootPath\console_output.log" -Force
+		New-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\services\$($serviceConfig.name)\Parameters" -Name "AppStderr" -Value "$rootPath\console_output_error.log" -Force
+		
 		if ($serviceConfig.arguments) {
 			New-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\services\$($serviceConfig.name)\Parameters" -Name "AppParameters" -Value "$($serviceConfig.arguments)" -Force
 		} else {


### PR DESCRIPTION
Set NSSM defaults to something sensible.

If they are not set it can cause entries in the Event viewer